### PR TITLE
fix(arch): enable SMP IPI support for Cortex-A9

### DIFF
--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -28,6 +28,8 @@ config CPU_CORTEX_A9
 	select ARMV7_A
 	select CPU_HAS_ICACHE
 	select CPU_HAS_DCACHE
+	select SCHED_IPI_SUPPORTED if SMP
+	select ARCH_HAS_DIRECTED_IPIS if SMP
 	help
 	  This option signifies the use of a Cortex-A9 CPU.
 


### PR DESCRIPTION
## Summary

- Cortex-A9 SMP has working `arch_sched_broadcast_ipi()` / `arch_sched_directed_ipi()` via GIC SGI in `smp.c`, but `CPU_CORTEX_A9` Kconfig never selected `SCHED_IPI_SUPPORTED` or `ARCH_HAS_DIRECTED_IPIS`
- This made `signal_pending_ipi()` compile to a no-op, silently disabling cross-CPU thread wakeups
- Any thread sleeping on CPU N woken by an ISR on CPU M had to wait for the next timer tick instead of receiving an immediate SGI — causing multi-second latencies with tickless kernel
- Mirrors what `AARCH32_ARMV8_R` already does (Kconfig line 180)

## Observed impact

| Metric | Before | After |
|---|---|---|
| 64 KB SD card read (interrupt-driven, cross-CPU event) | **10 s** | **360 ms** |
| Per-SD-request latency | 270 µs (unchanged) | 270 µs |

The per-request latency was always fine — the 10s was entirely from the thread not being woken up between requests.

## Test plan

- [x] Build `opus_one_75s` (Zynq-7000 dual Cortex-A9) — passes
- [x] Boot with SMP + tickless kernel — verified IPI fires, cross-CPU `k_event_wait` returns immediately
- [x] NLC LUT load timing: 10s → 360ms
- [ ] Verify no regression on single-core builds (`SMP=n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)