### PR TITLE
arch: arm: add OCM data section ROM copy for Cortex-A/R

### DIFF
--- a/arch/common/xip.c
+++ b/arch/common/xip.c
@@ -46,6 +46,10 @@ void arch_data_copy(void)
 	arch_early_memcpy(&__dtcm_data_start, &__dtcm_data_load_start,
 		       __dtcm_data_end - __dtcm_data_start);
 #endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_ocm))
+	arch_early_memcpy(&__ocm_data_start, &__ocm_data_load_start,
+		       __ocm_data_end - __ocm_data_start);
+#endif
 #ifdef CONFIG_CODE_DATA_RELOCATION
 	extern void data_copy_xip_relocation(void);
 

--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -345,10 +345,12 @@ GROUP_START(OCM)
 		*(.ocm_data)
 		*(".ocm_data.*")
 		__ocm_data_end = .;
-	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ocm)))
+	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ocm)) AT> ROMABLE_REGION)
 
-  __ocm_end = .;
-  __ocm_size = __ocm_end - __ocm_start;
+	__ocm_end = .;
+	__ocm_size = __ocm_end - __ocm_start;
+
+	__ocm_data_load_start = LOADADDR(_OCM_DATA_SECTION_NAME);
 
 GROUP_END(OCM)
 #endif

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -213,6 +213,7 @@ extern char __dtcm_end[];
 #if (DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_ocm)))
 extern char __ocm_data_start[];
 extern char __ocm_data_end[];
+extern char __ocm_data_load_start[];
 extern char __ocm_bss_start[];
 extern char __ocm_bss_end[];
 extern char __ocm_start[];


### PR DESCRIPTION
## Summary

- Add `AT> ROMABLE_REGION` to `.ocm_data` linker section so initialized data gets a ROM load address
- Add `__ocm_data_load_start` symbol to `linker-defs.h`
- Add `arch_early_memcpy` in `xip.c` to copy `.ocm_data` from ROM to OCM at startup

Mirrors the existing DTCM data copy pattern on Cortex-M. The `.ocm_data` section and `__ocm_data_section` macro already existed but the copy mechanism was missing, causing initialized data placed in OCM to come up zeroed.

## Test plan

- [ ] Build opus_one_75s (Zynq-7000) — verify `.ocm_data` section has VMA in OCM_HIGH and LMA in flash
- [ ] Verify non-zero SDO defaults survive boot when placed in `.ocm_data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>