### PR TITLE
[codex] fix ESC-side MDIO and YT8521 init robustness

### DIFF
--- a/drivers/ethernet/mdio/mdio_xlnx_esc.c
+++ b/drivers/ethernet/mdio/mdio_xlnx_esc.c
@@ -152,7 +152,11 @@ static int mdio_xlnx_esc_init(const struct device *dev)
 {
 	struct mdio_xlnx_esc_data *priv = dev->data;
 
-	DEVICE_MMIO_MAP(dev, K_MEM_PERM_RW);
+	/* ESC register space is shared with the main ESC driver and must stay
+	 * strongly ordered / uncached. A cached alias here can break MDIO busy
+	 * polling and command visibility on MMU-enabled Zynq targets.
+	 */
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	k_mutex_init(&priv->mutex);
 
 	LOG_DBG("ESC MDIO bus initialized (port %u)",

--- a/drivers/ethernet/phy/phy_motorcomm_yt8521.c
+++ b/drivers/ethernet/phy/phy_motorcomm_yt8521.c
@@ -523,6 +523,7 @@ static int mc_ytphy_get_id(const struct device *dev, uint32_t *phy_id)
 static int mc_ytphy_init(const struct device *dev)
 {
 	struct mc_ytphy_data *const data = dev->data;
+	const struct mc_ytphy_config *const cfg = dev->config;
 	int ret;
 
 	k_sem_init(&data->sem, 1, 1);
@@ -531,14 +532,27 @@ static int mc_ytphy_init(const struct device *dev)
 	data->dev = dev;
 	data->cb = NULL;
 
+	if (!device_is_ready(cfg->mdio)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->mdio);
+		return -ENODEV;
+	}
+
 	if (mc_ytphy_get_id(dev, NULL)) {
 		return -EIO;
 	}
 
 	/* set default reg space */
-	mc_ytphy_write_ext(dev, YT8521_REG_SPACE_SELECT_REG, YT8521_RSSR_UTP_SPACE);
+	ret = mc_ytphy_write_ext(dev, YT8521_REG_SPACE_SELECT_REG, YT8521_RSSR_UTP_SPACE);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to select UTP register space", cfg->phy_addr);
+		return ret;
+	}
 
-	mc_ytphy_modify_ext(dev, YTPHY_SYNCE_CFG_REG, YT8521_SCR_SYNCE_ENABLE, 0);
+	ret = mc_ytphy_modify_ext(dev, YTPHY_SYNCE_CFG_REG, YT8521_SCR_SYNCE_ENABLE, 0);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to disable SyncE", cfg->phy_addr);
+		return ret;
+	}
 
 	/* Reset PHY */
 	ret = mc_ytphy_soft_reset(dev);
@@ -547,11 +561,17 @@ static int mc_ytphy_init(const struct device *dev)
 	}
 
 	/* Enable clock delay */
-	mc_ytphy_cfg_clock_delay(dev);
+	ret = mc_ytphy_cfg_clock_delay(dev);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to configure RGMII delays", cfg->phy_addr);
+		return ret;
+	}
 
-	mc_ytphy_resume(dev);
-
-	const struct mc_ytphy_config *const cfg = dev->config;
+	ret = mc_ytphy_resume(dev);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to resume from power save", cfg->phy_addr);
+		return ret;
+	}
 
 	LOG_INF("Motorcomm YT8521 PHY %d initialized", cfg->phy_addr);
 	return 0;
@@ -573,7 +593,12 @@ static int mc_ytphy_initialize_dynamic_link(const struct device *dev)
 	k_work_init_delayable(&data->monitor_work, monitor_work_handler);
 
 	/* Advertise default speeds */
-	mc_ytphy_cfg_link(dev, config->default_speeds, 0);
+	ret = mc_ytphy_cfg_link(dev, config->default_speeds, 0);
+	if ((ret < 0) && (ret != -EALREADY)) {
+		LOG_ERR("PHY (%d) failed to configure advertised speeds (mask=0x%x, err=%d)",
+			config->phy_addr, config->default_speeds, ret);
+		return ret;
+	}
 
 	/* This will schedule the monitor work, if not already scheduled by mc_ytphy_cfg_link(). */
 	k_work_schedule(&data->monitor_work, K_NO_WAIT);


### PR DESCRIPTION
## Summary
- harden ESC-side YT8521 initialization so the driver fails explicitly when its MDIO bus is not ready
- propagate previously ignored ESC-side YT8521 init/config errors instead of silently continuing
- map the ESC MDIO register window as uncached MMIO to avoid stale MDIO busy/data visibility on MMU-enabled Zynq targets

## Root Cause
ESC-side PHY bring-up was unreliable for two separate reasons on the generic `xlnx,esc-mdio` + `motorcomm,yt8521` path:

1. The YT8521 driver could ignore MDIO/configuration failures and continue with weak diagnostics.
2. The ESC MDIO driver mapped the shared ESC register space without `K_MEM_CACHE_NONE`, creating a risky cached alias for MMIO accesses on Zynq MMU builds.

That combination made ESC-side PHY ID reads and speed-advertisement programming fail or become difficult to diagnose.

## Impact
- ESC-side PHY init errors are now explicit and actionable
- ESC MDIO accesses use the same uncached semantics as the main ESC register path
- the downstream servo branch can safely depend on this kernel branch for the validated ESC/PHY fix set

## Validation
- `west build -b opus_one_75s app/ -d build/opus_one_75s-app`
- on-target retest by user reported the fix path working as expected
