### PR TITLE
drivers: phy: avoid stale YT8521 autoneg state

### DIFF
--- a/drivers/ethernet/phy/phy_motorcomm_yt8521.c
+++ b/drivers/ethernet/phy/phy_motorcomm_yt8521.c
@@ -66,6 +66,8 @@ LOG_MODULE_REGISTER(phy_motorcomm_yt85xx, CONFIG_PHY_LOG_LEVEL);
 #define YTPHY_SYNCE_CFG_REG     0xA012
 #define YT8521_SCR_SYNCE_ENABLE BIT(5)
 
+#define YTPHY_LINK_BOUNDARY_DELAY_MS 500
+
 static int mc_ytphy_get_link_state(const struct device *dev, struct phy_link_state *state);
 
 struct mc_ytphy_config {
@@ -83,6 +85,7 @@ struct mc_ytphy_data {
 	struct phy_link_state state;
 	struct k_sem sem;
 	struct k_work_delayable monitor_work;
+	enum phy_link_speed advertised_speeds;
 	bool autoneg_in_progress;
 	k_timepoint_t autoneg_timeout;
 };
@@ -232,6 +235,44 @@ static int mc_ytphy_resume(const struct device *dev)
 	}
 
 	return mc_ytphy_modify(dev, MII_BMCR, MII_BMCR_POWER_DOWN, 0);
+}
+
+static int mc_ytphy_reset_datapath(const struct device *dev)
+{
+	const struct mc_ytphy_config *const cfg = dev->config;
+	int ret;
+
+	ret = mc_ytphy_write_ext(dev, YT8521_REG_SPACE_SELECT_REG, YT8521_RSSR_UTP_SPACE);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to select UTP register space", cfg->phy_addr);
+		return ret;
+	}
+
+	ret = mc_ytphy_modify_ext(dev, YTPHY_SYNCE_CFG_REG, YT8521_SCR_SYNCE_ENABLE, 0);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to disable SyncE", cfg->phy_addr);
+		return ret;
+	}
+
+	ret = mc_ytphy_soft_reset(dev);
+	if (ret) {
+		LOG_ERR("PHY (%d) soft reset failed", cfg->phy_addr);
+		return ret;
+	}
+
+	ret = mc_ytphy_cfg_clock_delay(dev);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to configure RGMII delays", cfg->phy_addr);
+		return ret;
+	}
+
+	ret = mc_ytphy_resume(dev);
+	if (ret) {
+		LOG_ERR("PHY (%d) failed to resume from power save", cfg->phy_addr);
+		return ret;
+	}
+
+	return 0;
 }
 
 static void invoke_link_cb(const struct device *dev)
@@ -427,6 +468,7 @@ static int mc_ytphy_cfg_link(const struct device *dev, enum phy_link_speed adv_s
 {
 	struct mc_ytphy_data *const data = dev->data;
 	const struct mc_ytphy_config *const cfg = dev->config;
+	bool force_link_boundary = false;
 	int ret = 0;
 
 	k_sem_take(&data->sem, K_FOREVER);
@@ -438,8 +480,25 @@ static int mc_ytphy_cfg_link(const struct device *dev, enum phy_link_speed adv_s
 			k_work_reschedule(&data->monitor_work, K_NO_WAIT);
 		}
 	} else {
+		force_link_boundary = data->state.is_up && (data->advertised_speeds != 0) &&
+				      (data->advertised_speeds != adv_speeds);
+		if (force_link_boundary) {
+			LOG_DBG("PHY (%d) forcing link boundary before advertised speed change",
+				cfg->phy_addr);
+			data->state.speed = 0;
+			data->state.is_up = false;
+			data->autoneg_in_progress = false;
+			ret = mc_ytphy_reset_datapath(dev);
+			if (ret < 0) {
+				goto cfg_link_end;
+			}
+			k_msleep(YTPHY_LINK_BOUNDARY_DELAY_MS);
+		}
+
 		ret = phy_mii_cfg_link_autoneg(dev, adv_speeds, true);
-		if (ret >= 0) {
+		if ((ret >= 0) || (force_link_boundary && (ret == -EALREADY))) {
+			ret = 0;
+			data->advertised_speeds = adv_speeds;
 			data->state.speed = 0;
 			data->state.is_up = false;
 			LOG_DBG("PHY (%d) Starting MII PHY auto-negotiate sequence", cfg->phy_addr);
@@ -455,10 +514,10 @@ static int mc_ytphy_cfg_link(const struct device *dev, enum phy_link_speed adv_s
 		LOG_DBG("PHY (%d) Link already configured", cfg->phy_addr);
 	}
 
+cfg_link_end:
 	k_sem_give(&data->sem);
 
 	return ret;
-
 }
 
 static int mc_ytphy_get_link_state(const struct device *dev, struct phy_link_state *state)
@@ -546,35 +605,8 @@ static int mc_ytphy_init(const struct device *dev)
 		return -EIO;
 	}
 
-	/* set default reg space */
-	ret = mc_ytphy_write_ext(dev, YT8521_REG_SPACE_SELECT_REG, YT8521_RSSR_UTP_SPACE);
+	ret = mc_ytphy_reset_datapath(dev);
 	if (ret) {
-		LOG_ERR("PHY (%d) failed to select UTP register space", cfg->phy_addr);
-		return ret;
-	}
-
-	ret = mc_ytphy_modify_ext(dev, YTPHY_SYNCE_CFG_REG, YT8521_SCR_SYNCE_ENABLE, 0);
-	if (ret) {
-		LOG_ERR("PHY (%d) failed to disable SyncE", cfg->phy_addr);
-		return ret;
-	}
-
-	/* Reset PHY */
-	ret = mc_ytphy_soft_reset(dev);
-	if (ret) {
-		return -EIO;
-	}
-
-	/* Enable clock delay */
-	ret = mc_ytphy_cfg_clock_delay(dev);
-	if (ret) {
-		LOG_ERR("PHY (%d) failed to configure RGMII delays", cfg->phy_addr);
-		return ret;
-	}
-
-	ret = mc_ytphy_resume(dev);
-	if (ret) {
-		LOG_ERR("PHY (%d) failed to resume from power save", cfg->phy_addr);
 		return ret;
 	}
 

--- a/drivers/ethernet/phy/phy_motorcomm_yt8521.c
+++ b/drivers/ethernet/phy/phy_motorcomm_yt8521.c
@@ -336,7 +336,8 @@ static int update_link_state(const struct device *dev)
 		return -EAGAIN;
 	}
 
-	data->state.is_up = true;
+	data->state.speed = 0;
+	data->state.is_up = false;
 
 	LOG_DBG("PHY (%d) Starting MII PHY auto-negotiate sequence", cfg->phy_addr);
 
@@ -439,6 +440,8 @@ static int mc_ytphy_cfg_link(const struct device *dev, enum phy_link_speed adv_s
 	} else {
 		ret = phy_mii_cfg_link_autoneg(dev, adv_speeds, true);
 		if (ret >= 0) {
+			data->state.speed = 0;
+			data->state.is_up = false;
 			LOG_DBG("PHY (%d) Starting MII PHY auto-negotiate sequence", cfg->phy_addr);
 			data->autoneg_in_progress = true;
 			data->autoneg_timeout =
@@ -464,8 +467,10 @@ static int mc_ytphy_get_link_state(const struct device *dev, struct phy_link_sta
 
 	k_sem_take(&data->sem, K_FOREVER);
 
-	update_link_state(dev);
 	memcpy(state, &data->state, sizeof(struct phy_link_state));
+	if (state->speed == 0) {
+		state->is_up = false;
+	}
 
 	k_sem_give(&data->sem);
 

--- a/drivers/ethernet/phy/phy_motorcomm_yt8521.c
+++ b/drivers/ethernet/phy/phy_motorcomm_yt8521.c
@@ -66,8 +66,6 @@ LOG_MODULE_REGISTER(phy_motorcomm_yt85xx, CONFIG_PHY_LOG_LEVEL);
 #define YTPHY_SYNCE_CFG_REG     0xA012
 #define YT8521_SCR_SYNCE_ENABLE BIT(5)
 
-#define YTPHY_LINK_BOUNDARY_DELAY_MS 500
-
 static int mc_ytphy_get_link_state(const struct device *dev, struct phy_link_state *state);
 
 struct mc_ytphy_config {
@@ -85,7 +83,6 @@ struct mc_ytphy_data {
 	struct phy_link_state state;
 	struct k_sem sem;
 	struct k_work_delayable monitor_work;
-	enum phy_link_speed advertised_speeds;
 	bool autoneg_in_progress;
 	k_timepoint_t autoneg_timeout;
 };
@@ -468,7 +465,6 @@ static int mc_ytphy_cfg_link(const struct device *dev, enum phy_link_speed adv_s
 {
 	struct mc_ytphy_data *const data = dev->data;
 	const struct mc_ytphy_config *const cfg = dev->config;
-	bool force_link_boundary = false;
 	int ret = 0;
 
 	k_sem_take(&data->sem, K_FOREVER);
@@ -480,25 +476,8 @@ static int mc_ytphy_cfg_link(const struct device *dev, enum phy_link_speed adv_s
 			k_work_reschedule(&data->monitor_work, K_NO_WAIT);
 		}
 	} else {
-		force_link_boundary = data->state.is_up && (data->advertised_speeds != 0) &&
-				      (data->advertised_speeds != adv_speeds);
-		if (force_link_boundary) {
-			LOG_DBG("PHY (%d) forcing link boundary before advertised speed change",
-				cfg->phy_addr);
-			data->state.speed = 0;
-			data->state.is_up = false;
-			data->autoneg_in_progress = false;
-			ret = mc_ytphy_reset_datapath(dev);
-			if (ret < 0) {
-				goto cfg_link_end;
-			}
-			k_msleep(YTPHY_LINK_BOUNDARY_DELAY_MS);
-		}
-
 		ret = phy_mii_cfg_link_autoneg(dev, adv_speeds, true);
-		if ((ret >= 0) || (force_link_boundary && (ret == -EALREADY))) {
-			ret = 0;
-			data->advertised_speeds = adv_speeds;
+		if (ret >= 0) {
 			data->state.speed = 0;
 			data->state.is_up = false;
 			LOG_DBG("PHY (%d) Starting MII PHY auto-negotiate sequence", cfg->phy_addr);
@@ -514,7 +493,6 @@ static int mc_ytphy_cfg_link(const struct device *dev, enum phy_link_speed adv_s
 		LOG_DBG("PHY (%d) Link already configured", cfg->phy_addr);
 	}
 
-cfg_link_end:
 	k_sem_give(&data->sem);
 
 	return ret;


### PR DESCRIPTION
Fixes #29.

## Summary
- keep YT8521 get_link read-only by returning the cached monitor state
- report autoneg-in-progress as down when no speed is available
- clear cached link speed when cfg_link restarts auto-negotiation

## Servo dependency
This is needed by panxxhub/zephyr-servo#669 so the ESC PHY policy does not make downgrade/restore decisions from stale YT8521 speed state.

## Test
- Built zephyr-servo app: west build -b opus_one_75s app/