### PR TITLE
drivers: phy: retry YT8521 ID probe while settling (#34)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-issue-34-yt8521-id-retry-impl-plan.md
+++ b/docs/superpowers/plans/2026-07-23-issue-34-yt8521-id-retry-impl-plan.md
@@ -1,0 +1,75 @@
+# Issue #34: YT8521 PHY ID Settling Retry Implementation Plan
+
+## 1. Establish the failing baseline
+
+- Confirm the worktree is based on `panxxhub/zephyr` `main`.
+- Record the existing `mc_ytphy_get_id()` behavior:
+  - 1000 iterations;
+  - 1 ms sleep only on MDIO read errors;
+  - no sleep after successful invalid reads.
+- Preserve the board evidence in issue #34 as the hardware regression
+  baseline.
+
+## 2. Implement the bounded settling retry
+
+Modify only:
+
+```text
+drivers/ethernet/phy/phy_motorcomm_yt8521.c
+```
+
+- Add named constants for 20 attempts and a 100 ms retry delay.
+- Track the last MDIO result, last PHY ID, and successful attempt number.
+- Accept YT8521 or YT8531 immediately.
+- Delay after both read failures and invalid IDs when another attempt
+  remains.
+- Emit one warning on delayed recovery.
+- Emit one terminal error on exhaustion and keep returning `-EIO`.
+
+## 3. Local validation
+
+- Run formatting/checkpatch-style validation on the modified driver.
+- Inspect the final diff for unrelated changes.
+- Build the Opus One Ctrl Gen1 application with
+  `/home/xpan/moton_ws/zephyr-issue-34` as `ZEPHYR_BASE`.
+- Confirm the generated image still selects
+  `CONFIG_PHY_MOTORCOMM_YT8521=y`.
+
+Because this fork has no focused PHY-driver unit-test harness, the direct
+regression test is the affected physical board. The generic Ethernet test
+suite provides only build coverage and cannot model the observed post-reset
+MDIO sequence.
+
+## 4. Hardware validation
+
+- JTAG-load the rebuilt non-encrypted application on the affected board.
+- Confirm there is no terminal `PHY (0) timeout to get PHY ID`.
+- Confirm the retry warning reports recovery after more than one attempt
+  when the marginal startup behavior occurs.
+- Verify ping to `169.254.0.42`.
+- Verify the CoAP endpoint is reachable.
+
+No QSPI write is required for the first validation pass.
+
+## 5. Review and merge the Zephyr hotfix
+
+- Commit the planning documents and implementation as intentional commits.
+- Push `fix/34-yt8521-id-retry`.
+- Open a draft PR that closes #34.
+- Run the repository review/check loop and classify any fork-inapplicable
+  upstream metadata failures separately from code/test failures.
+- Mark ready and merge only after validation and explicit approval.
+
+## 6. Advance zephyr-servo
+
+After the Zephyr PR is merged:
+
+- Tag the merge commit as the next immutable servo kernel tag
+  (`servo-kernel-v2`).
+- Create a separate zephyr-servo issue, branch, and worktree.
+- Update `west.yml` from `servo-kernel-v1` to `servo-kernel-v2`, including
+  the exact merge SHA and hotfix rationale in the adjacent comment.
+- Run `west update`/manifest resolution checks and a clean Ctrl Gen1
+  application build.
+- Open, review, and merge the zephyr-servo PR.
+

--- a/docs/superpowers/plans/2026-07-23-issue-34-yt8521-id-retry-impl-plan.md
+++ b/docs/superpowers/plans/2026-07-23-issue-34-yt8521-id-retry-impl-plan.md
@@ -1,5 +1,17 @@
 # Issue #34: YT8521 PHY ID Settling Retry Implementation Plan
 
+## Progress
+
+- [x] Implement bounded retry for read errors and invalid IDs.
+- [x] Pass `clang-format`, `checkpatch`, and diff validation.
+- [x] Build the Ctrl Gen1 application against the hotfix worktree.
+- [x] Confirm the build selects `CONFIG_PHY_MOTORCOMM_YT8521=y`.
+- [x] JTAG-load the hotfix ELF without writing QSPI.
+- [x] Verify stable ping and CoAP reachability.
+- [ ] Inspect the UART retry warning (intentionally skipped per user request).
+- [ ] Complete PR review/CI and merge.
+- [ ] Tag the merged kernel and advance `zephyr-servo/west.yml`.
+
 ## 1. Establish the failing baseline
 
 - Confirm the worktree is based on `panxxhub/zephyr` `main`.
@@ -72,4 +84,3 @@ After the Zephyr PR is merged:
 - Run `west update`/manifest resolution checks and a clean Ctrl Gen1
   application build.
 - Open, review, and merge the zephyr-servo PR.
-

--- a/docs/superpowers/specs/2026-07-23-issue-34-yt8521-id-retry-spec.md
+++ b/docs/superpowers/specs/2026-07-23-issue-34-yt8521-id-retry-spec.md
@@ -1,0 +1,71 @@
+# Issue #34: YT8521 PHY ID Settling Retry
+
+## Context
+
+`mc_ytphy_get_id()` in the Motorcomm YT8521/YT8531 PHY driver currently
+performs up to 1000 PHYID2 reads. It sleeps for 1 ms only when an MDIO
+transaction fails. A successful MDIO transaction that returns a transient
+invalid value, such as `0xffff`, is retried immediately.
+
+On an affected Opus One Ctrl Gen1 board, PHYID2 is unstable for about one
+second after reset release. The current loop can therefore exhaust all
+attempts before the PHY settles and device initialization fails with:
+
+```text
+E: PHY (0) timeout to get PHY ID
+```
+
+The YT8511 driver received a 20-attempt, 100 ms settling retry in #32/#33,
+but the affected hardware selects the YT8521 driver.
+
+## Goals
+
+- Cover the measured post-reset settling interval with a bounded retry.
+- Treat both MDIO read failures and successful invalid ID values as
+  retryable.
+- Preserve support for both YT8521 and YT8531 PHY IDs.
+- Avoid per-attempt log noise.
+- Preserve the driver's existing `-EIO` failure result.
+
+## Non-goals
+
+- Change PHY reset timing, RGMII delay configuration, autonegotiation, or
+  link-state behavior.
+- Change device-tree bindings or Kconfig.
+- Mask a permanently absent or unsupported PHY.
+- Add retry policy configuration to Kconfig or devicetree.
+
+## Required behavior
+
+1. Define a maximum of 20 PHY ID attempts and a 100 ms delay between
+   unsuccessful attempts.
+2. On each attempt, read `MII_PHYID2R`.
+3. Return success immediately when the value is `PHY_ID_YT8521` or
+   `PHY_ID_YT8531`.
+4. If the read fails or returns any other value, sleep for 100 ms only when
+   another attempt remains.
+5. If all attempts fail:
+   - emit one terminal error;
+   - include the last MDIO error or invalid ID in that error;
+   - return `-EIO`, matching the current public behavior.
+6. If a valid ID is obtained after the first attempt, emit one warning with
+   the successful attempt count.
+7. Preserve the existing `phy_id` output and debug-log behavior after a
+   successful probe.
+
+The maximum added settling window is 1.9 seconds because there are 19 delays
+between 20 attempts.
+
+## Acceptance criteria
+
+- A sequence of invalid IDs followed by `0x011a` initializes successfully.
+- A sequence of MDIO errors followed by a supported ID initializes
+  successfully.
+- A permanently invalid or unreadable PHY still fails after the bounded
+  interval.
+- The YT8521/YT8531 ID match and all unrelated driver behavior remain
+  unchanged.
+- The affected application builds cleanly against the hotfix.
+- On the affected board, JTAG boot no longer reports the PHY ID timeout,
+  `169.254.0.42` responds to ping, and the CoAP endpoint is reachable.
+

--- a/drivers/ethernet/phy/phy_motorcomm_yt8521.c
+++ b/drivers/ethernet/phy/phy_motorcomm_yt8521.c
@@ -28,6 +28,10 @@ LOG_MODULE_REGISTER(phy_motorcomm_yt85xx, CONFIG_PHY_LOG_LEVEL);
 #define PHY_ID_YT8521 (0x0000011A)
 #define PHY_ID_YT8531 (0x0000E91A)
 
+/* Allow a slow PHY clock/power domain to settle after reset. */
+#define YTPHY_PHY_ID_MAX_ATTEMPTS   20U
+#define YTPHY_PHY_ID_RETRY_DELAY_MS 100
+
 /* PHY Specific Status Register */
 #define SPEC_STATUS_REG_DUPLEX_MASK (1U << 13)
 #define PHY_DUPLEX_HALF             (0U << 13)
@@ -519,23 +523,34 @@ static int mc_ytphy_get_id(const struct device *dev, uint32_t *phy_id)
 {
 	const struct mc_ytphy_config *const config = dev->config;
 	uint32_t val = 0;
-	bool found = false;
+	uint32_t attempt;
+	int ret = 0;
 
-	for (uint32_t cnt = 1000; cnt > 0; cnt--) {
-		if (mc_ytphy_read(dev, MII_PHYID2R, &val) < 0) {
-			k_msleep(1);
-			continue;
+	for (attempt = 1U; attempt <= YTPHY_PHY_ID_MAX_ATTEMPTS; attempt++) {
+		ret = mc_ytphy_read(dev, MII_PHYID2R, &val);
+		if (ret == 0 && (val == PHY_ID_YT8521 || val == PHY_ID_YT8531)) {
+			break;
 		}
 
-		if (val == PHY_ID_YT8521 || val == PHY_ID_YT8531) {
-			found = true;
-			break;
+		if (attempt < YTPHY_PHY_ID_MAX_ATTEMPTS) {
+			k_msleep(YTPHY_PHY_ID_RETRY_DELAY_MS);
 		}
 	}
 
-	if (!found) {
-		LOG_ERR("PHY (%d) timeout to get PHY ID", config->phy_addr);
+	if (attempt > YTPHY_PHY_ID_MAX_ATTEMPTS) {
+		if (ret < 0) {
+			LOG_ERR("PHY (%d) failed to read ID after %u attempts (last error %d)",
+				config->phy_addr, YTPHY_PHY_ID_MAX_ATTEMPTS, ret);
+		} else {
+			LOG_ERR("PHY (%d) unsupported ID after %u attempts: 0x%X", config->phy_addr,
+				YTPHY_PHY_ID_MAX_ATTEMPTS, val);
+		}
+
 		return -EIO;
+	}
+
+	if (attempt > 1U) {
+		LOG_WRN("PHY (%d) ID became valid after %u attempts", config->phy_addr, attempt);
 	}
 
 	if (phy_id) {


### PR DESCRIPTION
## Linked Issue

- Closes #34

## Spec And Plan

- Spec: `docs/superpowers/specs/2026-07-23-issue-34-yt8521-id-retry-spec.md`
- Implementation plan: `docs/superpowers/plans/2026-07-23-issue-34-yt8521-id-retry-impl-plan.md`

## Implementation Summary

- Replace the YT8521/YT8531 PHY ID busy loop with 20 bounded attempts.
- Wait 100 ms after both MDIO read errors and successful invalid-ID reads when another attempt remains.
- Keep support for both existing PHY IDs and preserve the terminal `-EIO` behavior.
- Emit one recovery warning or one terminal error without per-attempt log noise.

## Validation

- `/usr/bin/clang-format-21 --dry-run --Werror drivers/ethernet/phy/phy_motorcomm_yt8521.c` — passed
- `git diff 4c15a22b51c -- drivers/ethernet/phy/phy_motorcomm_yt8521.c | scripts/checkpatch.pl --no-tree -` — 0 errors, 0 warnings
- `ZEPHYR_BASE=/home/xpan/moton_ws/zephyr-issue-34 west build -p always -b opus_one_ctrl_gen1 /home/xpan/moton_ws/zephyr-servo/app -d /tmp/zephyr-servo-issue-34-build` — passed
- Build selected `CONFIG_PHY_MOTORCOMM_YT8521=y`
- RT no-log call-graph validation — passed
- Baseline before JTAG load: ping 0/3, ARP incomplete
- Volatile JTAG load with v1.1.22 SyncTrace bitstream and the hotfix driver — passed
- Stable ping after settling: 10/10, 0% loss
- `servocli ping --url coap://169.254.0.42` — `reachable: true`
- Post-commit clean-build ELF SHA-256: `9712995dc3db7328e727542716c48c27b48f74fc8cbcd6776d69eccafa545076`
- Build banner: `servo-kernel-v1-2-g09b5873a796e`

## Known Limits

- The fork has no focused PHY-driver unit-test harness; the direct regression test used the affected physical board.
- UART retry-warning capture was intentionally skipped per bench instruction.
- The hardware pass used the identical driver diff before the final commit. The exact-commit ELF was rebuilt afterward; reloading it requires a fresh POR before another full PS7 initialization.
- Existing Ctrl Gen1 devicetree and FOC compiler warnings are unchanged and unrelated.