### PR TITLE
arch: arm: cortex_a_r: preserve ISR return across nested IRQs

### DIFF
--- a/arch/arm/core/cortex_a_r/isr_wrapper.S
+++ b/arch/arm/core/cortex_a_r/isr_wrapper.S
@@ -252,13 +252,35 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	add r0, #1
 	str r0, [r2, #___cpu_t_nested_OFFSET]
 
-	/* If not nested: switch to IRQ stack and save current sp on it. */
+	/*
+	 * If not nested, save the exception-frame SP on the IRQ stack, then
+	 * alias that stack into SYS mode.  Registered ISRs must not run in IRQ
+	 * mode: a nested IRQ would overwrite LR_irq after the handler call but
+	 * before the handler prologue can save it.
+	 *
+	 * Keep the private save record 8 bytes wide so the IRQ stack remains
+	 * aligned at public C call boundaries.
+	 */
 	cmp r0, #1
 	bhi 1f
 	mov r0, sp
 	cps #MODE_IRQ
-	push {r0}
+	push {r0, r1}
+	mov r0, sp
+	cps #MODE_SYS
+	mov sp, r0
 1:
+	/*
+	 * An IRQ may preempt code while its stack is only word-aligned.  Save
+	 * the exact frame pointer, then align the active ISR stack before any
+	 * public C interface is called.  This record is present at every
+	 * nesting level and is removed in z_arm_cortex_ar_irq_done.
+	 */
+	mov r0, sp
+	and r3, sp, #4
+	sub sp, sp, r3
+	push {r0, r3}
+
 #ifdef CONFIG_TRACING_ISR
 	bl sys_trace_isr_enter
 #endif /* CONFIG_TRACING_ISR */
@@ -339,28 +361,51 @@ z_arm_cortex_ar_irq_done:
 	str r0, [r2, #___cpu_t_nested_OFFSET]
 	/* Do not context switch if exiting a nested interrupt */
 	cmp r0, #0
-	/* Note that this function is only called from `z_arm_svc`,
-	 *	while handling irq_offload, with below modes set:
-	 *	```
-	 *		if (cpu interrupts are nested)
-	 *			mode=MODE_SYS
-	 *		else
-	 *			mode=MODE_IRQ
-	 *	```
-	 */
-	bhi __EXIT_INT
 
-	/* retrieve pointer to the current thread */
-	pop {r0}
-	cps #MODE_SYS
+	beq 1f
+
+#ifdef CONFIG_STACK_SENTINEL
+	bl z_check_stack_sentinel
+#endif /* CONFIG_STACK_SENTINEL */
+
+	/* Restore this nesting level's exact exception-frame SP. */
+	pop {r0, r1}
 	mov sp, r0
+	b z_arm_cortex_ar_exit_exc
 
+1:
+	/*
+	 * Ask the scheduler while still on the aligned IRQ-backed SYS stack.
+	 * Save the interrupted thread pointer because the call may update
+	 * _current.
+	 */
 	ldr r1, [r2, #___cpu_t_current_OFFSET]
-	push {r1}
+	push {r1, r2}
 	mov r0, #0
 	bl z_get_next_switch_handle
+	pop {r1, r2}
 
-	pop {r1}
+	/*
+	 * Remove the per-level alignment record, then restore the banked IRQ
+	 * stack and the interrupted thread's exact exception-frame SP.
+	 */
+	pop {r2, r3}
+	mov sp, r2
+	cps #MODE_IRQ
+	pop {r2, r3}
+	cps #MODE_SYS
+	mov sp, r2
+
+	/*
+	 * A thread may also have been interrupted with a word-aligned SP.
+	 * Keep an aligned restore record across a context switch so both the
+	 * assembly switch path and a later resumed exit recover the exact SP.
+	 */
+	mov r2, sp
+	and r3, sp, #4
+	sub sp, sp, r3
+	push {r2, r3}
+
 	cmp r0, #0
 	beq __EXIT_INT
 
@@ -373,10 +418,8 @@ z_arm_cortex_ar_irq_done:
 
 __EXIT_INT:
 
-#ifdef CONFIG_STACK_SENTINEL
-	bl z_check_stack_sentinel
-#endif /* CONFIG_STACK_SENTINEL */
-
+	pop {r2, r3}
+	mov sp, r2
 	b z_arm_cortex_ar_exit_exc
 
 #endif

--- a/arch/arm/core/cortex_a_r/switch.S
+++ b/arch/arm/core/cortex_a_r/switch.S
@@ -130,20 +130,44 @@ demux:
     beq offload
     b inv
 offload:
+    /*
+     * SVC entry masks IRQs.  Keep them masked while updating the nesting
+     * state and while running the offload callback, matching the existing
+     * irq_offload behavior.
+     */
+    cpsid i
+
     get_cpu r2
     ldr r3, [r2, #___cpu_t_nested_OFFSET]
     add r3, r3, #1
     str r3, [r2, #___cpu_t_nested_OFFSET]
 
-    /* If not nested: switch to IRQ stack and save current sp on it. */
+    /*
+     * If not nested, save the exception-frame SP on the IRQ stack, then
+     * alias that stack into SYS mode.  Running the callback in IRQ mode
+     * would expose its LR_irq return address to nested IRQ entry.
+     */
     cmp r3, #1
     bhi 1f
     mov r0, sp
     cps #MODE_IRQ
-    push {r0}
+    push {r0, r1}
+    mov r0, sp
+    cps #MODE_SYS
+    mov sp, r0
 
 1:
+    /*
+     * Match the hardware IRQ wrapper's per-level record: preserve the exact
+     * exception-frame SP and align the active stack before calling C.
+     */
+    mov r0, sp
+    and r3, sp, #4
+    sub sp, sp, r3
+    push {r0, r3}
+
     blx z_irq_do_offload
+    cpsid i
     b z_arm_cortex_ar_irq_done
 #endif
     b inv


### PR DESCRIPTION
## Summary

Fix the Cortex-A/R `CONFIG_USE_SWITCH` nested-IRQ return corruption tracked by #36.

Registered hardware ISRs now execute in `MODE_SYS` while retaining the per-CPU IRQ stack. This keeps the handler-call return address in `LR_sys`, which nested IRQ exception entry cannot overwrite through the singleton banked `LR_irq`.

At every nesting level, the wrapper saves the exact exception-frame SP and dynamically aligns the active stack to 8 bytes before public C calls. The outermost exit restores both banked stack pointers and preserves outermost-only scheduling. The same stack record is constructed by the `irq_offload` SVC path because both entries share `z_arm_cortex_ar_irq_done`.

## Root cause

The first-level wrapper enabled nesting and called the registered handler while still in IRQ mode. `blx` therefore placed the wrapper return address in `LR_irq`. A higher-priority IRQ arriving before the selected handler's first LR-saving prologue instruction overwrote that address. The outer ISR later returned to the wrong PC, producing the observed prefetch-abort fatal halt.

## Preserved behavior

- Per-CPU IRQ stacks and SMP nesting accounting
- GIC acknowledge/EOI ordering and spurious IRQ handling
- Outermost-only context switching
- Existing `irq_offload` IRQ-mask semantics: the callback remains masked
- Existing FPU behavior; no VFP state or instructions are added
- AAPCS 8-byte stack alignment at every C call boundary
- Genuine IRQ priority hierarchy; no priority flattening

## Base and scope

- Based on `main` at `e01235ab628`, the merge of #38.
- One atomic DCO-signed commit; two files changed.
- `switch.S` changes are confined to the `irq_offload` SVC entry. The core `z_arm_context_switch` save/restore implementation is unchanged.

## Validation

- PASS: clean `opus_one_75s/xc7z020` product build at head `84bcd5b7437` (464 steps).
- PASS: RT no-log guard; 240 real-time-reachable functions contain no log/printk entry point.
- PASS: existing `qemu_cortex_a9` interrupt suite with `CONFIG_USE_SWITCH=y`: 5 passed, 0 failed, 1 expected skip. A test-only no-SLCR overlay is required because the fork's normal QEMU boot accesses unmapped SLCR before ztest; the same limitation exists on `main`.
- PASS: assembly-path audit covering banked LR/SP lifetime, every nesting-level record, SMP accounting, GIC ordering, offload mask state, and outermost scheduling.
- Targeted hardware evidence: an earlier source revision (`29a1455f`) did not reproduce the former 7.5–8 s PS-wide freeze during a 60-second, two-slave, 250 us smoke run with the genuine IRQ hierarchy; ping was 260/260 and CoAP was 62/62. This is evidence for the root fix, not acceptance of the current head.
- Pending: deterministic regression for the exact `blx`-to-first-prologue window.
- Pending: current-head Ctrl Gen1 acceptance for at least 30 minutes with ESC IRQ61=`0x90`, timer/GEM=`0xA0`, continuous ping/CoAP, and EtherCAT state transitions.

## Review artifact

Chinese implementation and validation report: https://artifacts.sz-icnc.com/zephyr-servo/kernel/issue36-pr39-update/

Fixes #36.
